### PR TITLE
add GameOasis

### DIFF
--- a/hackathons/InOut6.md
+++ b/hackathons/InOut6.md
@@ -1,0 +1,13 @@
+HACKATHON_NAME: InOut 6.0
+
+LINK_TO_HACKATHON_WEBSITE: https://hackinout.co/
+
+HACKATHON_DATES: October 19, 2019 - October 20, 2019
+
+HACKATHON_TYPE: PHYSICAL
+
+HACKATHON_LOCATION: MLR Convention Centre, JP Nagar, Bengaluru
+
+LAST_APPLICATION_DATETIME: October 5th, 2019
+
+SPEAKERS: Arpit Agarwal, Sudhanshu Yadav, Srijan Agarwal, Ashu Pachauri, Vikas Parashar, Jaynti Kanani, Bhagat Singh, Gauri Kanekar


### PR DESCRIPTION
HACKATHON_NAME: Game Oasis Hackathon

LINK_TO_HACKATHON_WEBSITE: https://gameoasis.info/

HACKATHON_DATES: OCT 25 , 2019 - OCT 27, 2019

HACKATHON_TYPE: PHYSICAL

HACKATHON_LOCATION: BitTemple San Francisco, Three Embarcadero Center, Promenade Level Suite P5, 
San Francisco, CA 94111

LAST_APPLICATION_DATETIME: October 25th, 2019